### PR TITLE
KRR fix

### DIFF
--- a/mlqm/mlqm/core.py
+++ b/mlqm/mlqm/core.py
@@ -210,7 +210,7 @@ class Dataset(object):
             elif isinstance(inpf,dict):
                 self.inpf = None
                 self.setup = inpf['setup']
-                self.data = inp['data']
+                self.data = inpf['data']
             else:
                 print("Please pass in either a STR json filepath or DICT.")
 
@@ -257,7 +257,7 @@ class Dataset(object):
             elif isinstance(inpf,dict):
                 self.inpf = None
                 self.setup = inpf['setup']
-                self.data = inp['data']
+                self.data = inpf['data']
             else:
                 print("Please pass in either a STR json filepath or DICT.")
 

--- a/mlqm/mlqm/core.py
+++ b/mlqm/mlqm/core.py
@@ -107,7 +107,14 @@ class PES(object):
         top = float(self.dis[1])
         base = self.geom
         gvar = self.gvar
-        pes = np.linspace(bot,top,self.pts) 
+#        pes = np.linspace(bot,top,self.pts) 
+        pes = [bot]
+
+        x = bot
+        for i in range(0,self.pts-1):
+            x += (top - bot) / self.pts
+            pes.append(x)
+        pes = np.round(pes,4)
     
         if not global_options:
             global_options = {

--- a/mlqm/mlqm/core.py
+++ b/mlqm/mlqm/core.py
@@ -88,7 +88,7 @@ class PES(object):
             json.dump(settings,f,indent=4)
         # }}}
 
-    def generate(self, global_options=False, regen=False,**kwargs):
+    def generate(self, global_options=False, pestype='INCLUDE', regen=False,**kwargs):
         # {{{
         '''
         Generate the input files across a PES.
@@ -107,14 +107,17 @@ class PES(object):
         top = float(self.dis[1])
         base = self.geom
         gvar = self.gvar
-#        pes = np.linspace(bot,top,self.pts) 
-        pes = [bot]
-
-        x = bot
-        for i in range(0,self.pts-1):
-            x += (top - bot) / self.pts
-            pes.append(x)
-        pes = np.round(pes,4)
+        if pestype.upper() == "INCLUDE":
+            pes = np.linspace(bot,top,self.pts) 
+        elif pestype.upper() == "EXCLUDE":
+            pes = [bot]
+            x = bot
+            for i in range(0,self.pts-1):
+                x += (top - bot) / self.pts
+                pes.append(x)
+            pes = np.round(pes,4)
+        else:
+            raise Exception("PES type {} not recognized.".format(pestype))
     
         if not global_options:
             global_options = {

--- a/mlqm/mlqm/datahelper.py
+++ b/mlqm/mlqm/datahelper.py
@@ -183,32 +183,49 @@ def harvest_amps(method,namps=150,outfile="output.dat"):
 # {{{
     """
     Harvest amplitudes from an output file. Useful for when
-    get_amps() cannot be used (ie symmetry not C1)
+    get_amps() cannot be used (ie symmetry not C1). Currently
+    only implemented for RHF reference (TIA and TIjAb amps)
     """
     if method.upper() == "MP2":
         # MP2 amps print before CCSD amps
-        mcheck = "Largest TIjAb Amplitudes:"
+        mcheck = ["Largest TIjAb Amplitudes:"]
+        ttype = ['t2']
         amps = {'t2':[]}
-#    elif method.upper() == "CCSD":
-#        # Convergence is always printed before CCSD amps
-#        mcheck = "Iterations converged."
-#        amps = {'t1':[],'t2':[]}
+    elif method.upper() == "CCSD":
+        mcheck = ["Largest TIA Amplitudes:","Largest TIjAb Amplitudes:"]
+        ttype = ['t1','t2']
+        amps = {'t1':[],'t2':[]}
     else:
         raise Exception("Cannot harvest {} amplitudes.".format(method))
 
     get_line = 0
     get_next = 0
+    t = 0 # amplitudes will always be printed in order t1, t2, t3 . . .
     with open(outfile) as f:
         for line in f:
             if (get_next == 1) & (get_line < namps):
+                if (t < len(ttype) - 1):
+                    if mcheck[t+1] in line: # just in case amps run out before namps
+                        get_line = 0
+                        t += 1
+                        pass
                 try:
-                    _,_,_,_,amp = line.split()
-                    amps['t2'].append(float(amp))
+                    if ttype[t] == 't1':
+                        _,_,amp = line.split()
+                    elif ttype[t] == 't2':
+                        _,_,_,_,amp = line.split()
+                    else:
+                        raise Exception("Can't handle {} amps just yet!".format(ttype[t]))
+                    amps[ttype[t]].append(float(amp))
                     get_line += 1
                 except:
                     pass
-            elif mcheck in line:
+            elif mcheck[t] in line:
                 get_next += 1
+            elif (get_line >= namps) and (t < len(ttype) - 1):
+                get_line = 0
+                get_next = 0
+                t += 1
             else:
                 pass
 

--- a/mlqm/mlqm/datahelper.py
+++ b/mlqm/mlqm/datahelper.py
@@ -112,6 +112,10 @@ def get_amps(wfn,method):
     Grab aomplutudes from the wfn
     CCSD just uses wfn.get_amplitudes()
     MP2 builds them from the integrals, Fock, and Hamiltonian
+    NOTE: wfn.get_amplitudes() only works for C1 symmetry, 
+    and the MP2 amplitude generation is only intended for C1
+    symmetry (AO->MO transformation done w/out regard for
+    AO->SO transformation)
     Returns dictionary with amplitudes
     '''
     if method.upper() == "CCSD":
@@ -174,6 +178,38 @@ def get_amps(wfn,method):
     
     return amps
     # }}}
+
+def harvest_amps(method,namps=150,outfile="output.dat"):
+    """
+    Harvest amplitudes from an output file. Useful for when
+    get_amps() cannot be used (ie symmetry not C1)
+    """
+    if method.upper() == "MP2":
+        # MP2 amps print before CCSD amps
+        mcheck = "Largest TIjAb Amplitudes:"
+        amps = {'t2':[]}
+#    elif method.upper() == "CCSD":
+#        # Convergence is always printed before CCSD amps
+#        mcheck = "Iterations converged."
+#        amps = {'t1':[],'t2':[]}
+    else:
+        raise Exception("Cannot harvest {} amplitudes.".format(method))
+
+
+    get_line = 0
+    get_next = 0
+    with open(outfile) as f:
+        for line in outfile:
+            if (get_next == 1) & (get_line < namps):
+                try:
+                    _,_,_,_,amp = line.split()
+                    amps['t1'].append(float(amp))
+                    get_line += 1
+                except:
+                    pass
+            if mcheck in outfile:
+                get_next += 1
+    return amps
 
 def reg_l2(y,y_p,l,a):
 # {{{

--- a/mlqm/mlqm/datahelper.py
+++ b/mlqm/mlqm/datahelper.py
@@ -180,6 +180,7 @@ def get_amps(wfn,method):
     # }}}
 
 def harvest_amps(method,namps=150,outfile="output.dat"):
+# {{{
     """
     Harvest amplitudes from an output file. Useful for when
     get_amps() cannot be used (ie symmetry not C1)
@@ -195,21 +196,26 @@ def harvest_amps(method,namps=150,outfile="output.dat"):
     else:
         raise Exception("Cannot harvest {} amplitudes.".format(method))
 
-
     get_line = 0
     get_next = 0
     with open(outfile) as f:
-        for line in outfile:
+        for line in f:
             if (get_next == 1) & (get_line < namps):
                 try:
                     _,_,_,_,amp = line.split()
-                    amps['t1'].append(float(amp))
+                    amps['t2'].append(float(amp))
                     get_line += 1
                 except:
                     pass
-            if mcheck in outfile:
+            elif mcheck in line:
                 get_next += 1
+            else:
+                pass
+
+    for t in amps:
+        amps[t] = np.asarray(amps[t])
     return amps
+# }}}
 
 def reg_l2(y,y_p,l,a):
 # {{{

--- a/mlqm/mlqm/repgen.py
+++ b/mlqm/mlqm/repgen.py
@@ -53,6 +53,9 @@ def make_tatr(method,t2,t1=None,x=150,st=0.05):
         print("I don't know how to handle {} amplitudes.".format(method))
         raise Exception("{} amplitude representations not supported!".format(method))
 
+#    # normalize to integral(TATR) = 1
+#    tatr = [i/sum(tatr) for i in tatr]
+
     return np.asarray(tatr)
 # }}}
 
@@ -128,7 +131,7 @@ def gaus(x, u, s):
     return a gaussian centered on u with width s
     note: we're using x within [-1,1]
     '''
-    return np.exp(-(x-u)**2 / (2.0*s**2))
+    return np.exp(-1 * (x-u)**2 / (2.0*s**2))
 # }}}
 
 def legacy_CCSD_NAT():

--- a/mlqm/mlqm/repgen.py
+++ b/mlqm/mlqm/repgen.py
@@ -53,9 +53,6 @@ def make_tatr(method,t2,t1=None,x=150,st=0.05):
         print("I don't know how to handle {} amplitudes.".format(method))
         raise Exception("{} amplitude representations not supported!".format(method))
 
-#    # normalize to integral(TATR) = 1
-#    tatr = [i/sum(tatr) for i in tatr]
-
     return np.asarray(tatr)
 # }}}
 

--- a/mlqm/mlqm/train.py
+++ b/mlqm/mlqm/train.py
@@ -67,16 +67,30 @@ def cen_err(maps):
     Return the stddv of the mean center->point diffs
     Also return the positions of the closest points to each center
     '''
+    min_diff = -1
+
     errors = []
     close_pts = []
     for i in range(0,len(maps)): # loop over centers
         cen = np.mean([c[0] for c in maps[i]],axis=0) # mean of coords in center i
         diffs = [] # hold diffs for center i
         for j in range(0,len(maps[i])): # loop over points
-            diffs.append(la.norm(maps[i][j][0] - cen)) # norm of diff btwn point and cen
-        errors.append(np.mean(diffs)) # store the mean error for center i
+
+#            diffs.append(la.norm(maps[i][j][0] - cen)) # norm of diff btwn point and cen
+#        errors.append(np.mean(diffs)) # store the mean error for center i
+#        close_pts.append(np.argmin(diffs)) # store the position of the closest point to center i
+#    return np.std(errors), close_pts
+
+
+            diff = -2 * np.dot(maps[i][j][0],cen)
+            diff += la.norm(maps[i][j][0]) ** 2.0
+            diff += la.norm(cen) ** 2.0
+            diffs.append(diff)
+            if min_diff == -1 or diff < min_diff:
+                min_diff = diff
+        errors.append(min_diff) # store the lowest diff for center i 
         close_pts.append(np.argmin(diffs)) # store the position of the closest point to center i
-    return np.std(errors), close_pts
+    return sum(errors), close_pts
 # }}}
 
 def cluster(pts,M,cens):

--- a/mlqm/mlqm/train.py
+++ b/mlqm/mlqm/train.py
@@ -75,13 +75,6 @@ def cen_err(maps):
         cen = np.mean([c[0] for c in maps[i]],axis=0) # mean of coords in center i
         diffs = [] # hold diffs for center i
         for j in range(0,len(maps[i])): # loop over points
-
-#            diffs.append(la.norm(maps[i][j][0] - cen)) # norm of diff btwn point and cen
-#        errors.append(np.mean(diffs)) # store the mean error for center i
-#        close_pts.append(np.argmin(diffs)) # store the position of the closest point to center i
-#    return np.std(errors), close_pts
-
-
             diff = -2 * np.dot(maps[i][j][0],cen)
             diff += la.norm(maps[i][j][0]) ** 2.0
             diff += la.norm(cen) ** 2.0


### PR DESCRIPTION
Resolves #13. 

The main issue seems to have been the amplitudes; when molecular symmetry is considered for diatomics, it would seem the resulting amplitudes are far better suited for representing the wavefunction. A proper examination of this will be done now that the main problem is found. 

Added an option to harvest amplitudes from text output files, for when amplitudes aren't readily available through PsiAPI (IE, when symmetry is on). Also changed the error metric in k-means to better match `scikit-learn`, though there still seems to be some difference in the resulting clusters. Finally, added options for including or excluding the endpoints in a PES (ie, 200 points in [0.5,2.0] w/ 2.0 included and w/o). 

Bonus: resolve #12 as well, because mucking about in `core.py` already.