### PR TITLE
Dtr2

### DIFF
--- a/mlqm/mlqm/datahelper.py
+++ b/mlqm/mlqm/datahelper.py
@@ -179,7 +179,7 @@ def get_amps(wfn,method):
     return amps
     # }}}
 
-def harvest_amps(method,nocc,nvir,namps=150,outfile="output.dat"):
+def harvest_amps(method,namps=150,outfile="output.dat"):
 # {{{
     """
     Harvest amplitudes from an output file. Useful for when
@@ -190,11 +190,11 @@ def harvest_amps(method,nocc,nvir,namps=150,outfile="output.dat"):
         # MP2 amps print before CCSD amps
         mcheck = ["Largest TIjAb Amplitudes:"]
         ttype = ['t2']
-        amps = {'t2':np.zeros((nocc,nocc,nvir,nvir))}
+        amps = {'t2':[]}
     elif method.upper() == "CCSD":
         mcheck = ["Largest TIA Amplitudes:","Largest TIjAb Amplitudes:"]
         ttype = ['t1','t2']
-        amps = {'t1':np.zeros((nocc,nvir)),'t2':np.zeros((nocc,nocc,nvir,nvir))}
+        amps = {'t1':[],'t2':[]}
     else:
         raise Exception("Cannot harvest {} amplitudes.".format(method))
 
@@ -211,13 +211,12 @@ def harvest_amps(method,nocc,nvir,namps=150,outfile="output.dat"):
                         pass
                 try:
                     if ttype[t] == 't1':
-                        i,a,amp = line.split()
-                        amps['t1'][int(i)][int(a)] = float(amp)
+                        _,_,amp = line.split()
                     elif ttype[t] == 't2':
-                        i,j,a,b,amp = line.split()
-                        amps['t2'][int(i)][int(j)][int(a)][int(b)] = float(amp)
+                        _,_,_,_,amp = line.split()
                     else:
                         raise Exception("Can't handle {} amps just yet!".format(ttype[t]))
+                    amps[ttype[t]].append(float(amp))
                     get_line += 1
                 except:
                     pass

--- a/mlqm/mlqm/datahelper.py
+++ b/mlqm/mlqm/datahelper.py
@@ -179,7 +179,7 @@ def get_amps(wfn,method):
     return amps
     # }}}
 
-def harvest_amps(method,namps=150,outfile="output.dat"):
+def harvest_amps(method,nocc,nvir,namps=150,outfile="output.dat"):
 # {{{
     """
     Harvest amplitudes from an output file. Useful for when
@@ -190,11 +190,11 @@ def harvest_amps(method,namps=150,outfile="output.dat"):
         # MP2 amps print before CCSD amps
         mcheck = ["Largest TIjAb Amplitudes:"]
         ttype = ['t2']
-        amps = {'t2':[]}
+        amps = {'t2':np.zeros((nocc,nocc,nvir,nvir))}
     elif method.upper() == "CCSD":
         mcheck = ["Largest TIA Amplitudes:","Largest TIjAb Amplitudes:"]
         ttype = ['t1','t2']
-        amps = {'t1':[],'t2':[]}
+        amps = {'t1':np.zeros((nocc,nvir)),'t2':np.zeros((nocc,nocc,nvir,nvir))}
     else:
         raise Exception("Cannot harvest {} amplitudes.".format(method))
 
@@ -211,12 +211,13 @@ def harvest_amps(method,namps=150,outfile="output.dat"):
                         pass
                 try:
                     if ttype[t] == 't1':
-                        _,_,amp = line.split()
+                        i,a,amp = line.split()
+                        amps['t1'][int(i)][int(a)] = float(amp)
                     elif ttype[t] == 't2':
-                        _,_,_,_,amp = line.split()
+                        i,j,a,b,amp = line.split()
+                        amps['t2'][int(i)][int(j)][int(a)][int(b)] = float(amp)
                     else:
                         raise Exception("Can't handle {} amps just yet!".format(ttype[t]))
-                    amps[ttype[t]].append(float(amp))
                     get_line += 1
                 except:
                     pass

--- a/mlqm/mlqm/repgen.py
+++ b/mlqm/mlqm/repgen.py
@@ -75,10 +75,10 @@ def make_dtr(opdm,t2,x=300,st=0.05):
     for i in range(0,x):
         val1 = 0
         val2 = 0
-        for p_1 in range(0,len(Ppq)):
-            val1 += gaus(x_list[i],Ppq[p_1],st)
-        for p_2 in range(0,len(Ppqrs)):
-            val2 += gaus(x_list[i],Ppqrs[p_2],st)
+        for p_1 in range(0,len(opdm)):
+            val1 += gaus(x_list[i],opdm[p_1],st)
+        for p_2 in range(0,len(tpdm)):
+            val2 += gaus(x_list[i],tpdm[p_2],st)
         dtr.append(val1)
         dtr.append(val2)
 


### PR DESCRIPTION
Density Tensor Representations now via OPDM and T2 amplitudes (since the TPDM is just made of pure T2 amplitudes). Moved old dtr function to legacy, may re-implement the generation of the PDMs Psi4NumPy-style if necessary for C1 symmetry and/or non-DF-MP2. 

Note that this was done because Psi4NumPy-style PDM generation doesn't work as easily with non-C1 symmetry, and Psi4 is faster anyway. Downside is all calculations must be run through DF-MP2 to do a properties calculation (so that the density is updated in the wfn).