### PR TITLE
Optimize DTR

### DIFF
--- a/mlqm/mlqm/repgen.py
+++ b/mlqm/mlqm/repgen.py
@@ -66,25 +66,25 @@ def make_dtr(opdm,tpdm=None,x=150,st=0.05,cut_type='full',cut_val=None):
     st: width of gaussians summed along the tensor (default 0.05)
     cut_type: type of cutoff of PDM elements after ravel and magnitude sort
         'full': use all elements (ignore cut_val)
-        'max': use all elements above float(cut_val)
+        'min': use all elements above float(cut_val)
         'top': use highest int(cut_val) elements
         'percent': use highest float(cut_val)*100% elements
-        'percent_max': tuple(m,n) highest float(m)*100% elements with magnitude greater than float(n)
+        'percent_min': tuple(m,n) highest float(m)*100% elements with magnitude greater than float(n)
     cut_val: value used in above cut_type (ignored if cut_type == 'full', type must match)
     """
 
     # sort OPDM and t2 by magnitude (sorted(x,key=abs) will ignore sign) 
-    opdm = sorted(opdm.ravel(),key=abs)
+    opdm = np.array(sorted(opdm.ravel(),key=abs))
     if tpdm:
-        tpdm = sorted(tpdm.ravel(),key=abs)
+        tpdm = np.array(sorted(tpdm.ravel(),key=abs))
 
     # deal with cutoffs
     if cut_type.lower() == 'full':
         pass
-    elif cut_type.lower() == 'max':
-        opdm = opdm[abs[opdm] > cut_val]
+    elif cut_type.lower() == 'min':
+        opdm = opdm[abs(opdm) > cut_val]
         if tpdm:
-            tpdm = tpdm[abs[tpdm] > cut_val]
+            tpdm = tpdm[abs(tpdm) > cut_val]
     elif cut_type.lower() == 'top':
         opdm = opdm[-cut_val:]
         if tpdm:
@@ -93,12 +93,14 @@ def make_dtr(opdm,tpdm=None,x=150,st=0.05,cut_type='full',cut_val=None):
         opdm = opdm[-round(cut_val*len(opdm)):]
         if tpdm:
             tpdm = tpdm[-round(cut_val*len(tpdm)):]
-    elif cut_type.lower() == 'percent_max':
-        opdm = opdm[abs[opdm] > cut_val[1]]
+    elif cut_type.lower() == 'percent_min':
+        opdm = opdm[abs(opdm) > cut_val[1]]
         opdm = opdm[-round(cut_val[0]*len(opdm)):]
         if tpdm:
-            tpdm = tpdm[abs[tpdm] > cut_val[1]]
+            tpdm = tpdm[abs(tpdm) > cut_val[1]]
             tpdm = tpdm[-round(cut_val[0]*len(tpdm)):]
+    else:
+        raise RuntimeError("Cutoff type '{}' not recognized.".format(cut_type))
 
     # make a discretized gaussian using the PDMs
     dtr = [] # store eq vals

--- a/mlqm/mlqm/repgen.py
+++ b/mlqm/mlqm/repgen.py
@@ -103,16 +103,13 @@ def make_dtr(opdm,tpdm=None,x=150,st=0.05,cut_type='full',cut_val=None):
     # make a discretized gaussian using the PDMs
     dtr = [] # store eq vals
     x_list = np.linspace(-1,1,x)
-    for i in range(0,x):
-        val1 = 0
-        for p_1 in range(0,len(opdm)):
-            val1 += gaus(x_list[i],opdm[p_1],st)
-        dtr.append(val1)
 
+    # sum over d-centered gaussians for every x
+    for i in range(0,x):
+        val1 = sum([gaus(x_list[i],d,st) for d in opdm])
+        dtr.append(val1)
         if tpdm:
-            val2 = 0
-            for p_2 in range(0,len(tpdm)):
-                val2 += gaus(x_list[i],tpdm[p_2],st)
+            val2 = sum([gaus(x_list[i],d,st) for d in tpdm])
             dtr.append(val2)
 
     return np.asarray(dtr)
@@ -121,8 +118,7 @@ def make_dtr(opdm,tpdm=None,x=150,st=0.05,cut_type='full',cut_val=None):
 def gaus(x, u, s):
 # {{{
     '''
-    return a gaussian centered on u with width s
-    note: we're using x within [-1,1]
+    return a gaussian point x centered on u with width s
     '''
     return np.exp(-1 * (x-u)**2 / (2.0*s**2))
 # }}}

--- a/mlqm/mlqm/repgen.py
+++ b/mlqm/mlqm/repgen.py
@@ -56,31 +56,33 @@ def make_tatr(method,t2,t1=None,x=150,st=0.05):
     return np.asarray(tatr)
 # }}}
 
-def make_dtr(opdm,t2,x=150,st=0.05):
+def make_dtr(opdm,tpdm=None,x=150,st=0.05):
 # {{{
     """
     Making a DTR. Currently implemented for MP2 only.
-    Pass in the OPDM given by wfn.Da() plus any T2
-    amplitudes (as the TPDM is simply amplitudes)
+    Pass in the OPDM given by wfn.Da() plus optional TPDM 
     """
 
     # sort OPDM and t2 by magnitude (sorted(x,key=abs) will ignore sign) 
     # subbing in t2 for TPDM
     opdm = sorted(opdm.ravel(),key=abs)[-x:]
-    tpdm = sorted(t2.ravel(),key=abs)[-x:]
+    if tpdm:
+        tpdm = sorted(tpdm.ravel(),key=abs)[-x:]
 
     # make a discretized gaussian using the PDMs
     dtr = [] # store eq vals
     x_list = np.linspace(-1,1,x)
     for i in range(0,x):
         val1 = 0
-        val2 = 0
         for p_1 in range(0,len(opdm)):
             val1 += gaus(x_list[i],opdm[p_1],st)
-        for p_2 in range(0,len(tpdm)):
-            val2 += gaus(x_list[i],tpdm[p_2],st)
         dtr.append(val1)
-        dtr.append(val2)
+
+        if tpdm:
+            val2 = 0
+            for p_2 in range(0,len(tpdm)):
+                val2 += gaus(x_list[i],tpdm[p_2],st)
+            dtr.append(val2)
 
     return np.asarray(dtr)
 # }}}


### PR DESCRIPTION
In light of recent test data, the DTR is getting a slight overhaul. Of particular interest is deciding how many elements of the OPDM to consider when building the DTR. 

- [x] Make TPDM optional 
- [x] Rework cutoff criteria 
- - [x] Number of elements cutoff
- - [x] Percentage cutoff
- - [x] Absolute value cutoff
- - [x] Mixed cutoff (percent above absolute value)
- [ ] Speed-ups
- - [x] List comprehension
- - [ ] Reject density elements d such that `g(x,d,s) == 0` to within machine precision
- - [ ] Option to parallelize sums?
- [x] Tests
- - [x] Test new options
